### PR TITLE
Public outgoing

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1441,7 +1441,8 @@
         return handleProfileUpdate({ data, confirm, messageDescriptor });
       }
 
-      const ourNumber = textsecure.storage.user.getNumber();
+      const primaryDeviceKey = window.storage.get('primaryDevicePubKey');
+      const allOurDevices = await libloki.storage.getAllDevicePubKeysForPrimaryPubKey(primaryDeviceKey);
       const descriptorId = await textsecure.MessageReceiver.arrayBufferToString(
         messageDescriptor.id
       );
@@ -1449,7 +1450,7 @@
       if (
         messageDescriptor.type === 'group' &&
         descriptorId.match(/^publicChat:/) &&
-        data.source === ourNumber
+        allOurDevices.includes(data.source)
       ) {
         // Public chat messages from ourselves should be outgoing
         message = await createSentMessage(data);

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1270,7 +1270,11 @@
 
           this.trigger('sent', this);
           if (this.get('type') !== 'friend-request') {
-            this.sendSyncMessage();
+            const c = this.getConversation();
+            // Don't bother sending sync messages to public chats
+            if (!c.isPublic()) {
+              this.sendSyncMessage();
+            }
           }
         })
         .catch(result => {


### PR DESCRIPTION
Stop sending sync messages to public chats and mark messages from any of our devices as outgoing